### PR TITLE
Add support for system wide copy-paste

### DIFF
--- a/etc/skel/.config/micro/settings.json
+++ b/etc/skel/.config/micro/settings.json
@@ -1,3 +1,4 @@
 {
     "colorscheme": "catppuccin-macchiato"
+    "clipboard": "terminal"
 }


### PR DESCRIPTION
use OSC 52 sequences to support system wide copy\paste, since cachyOS package does not depend on `xcut` or alike anyway, and hence copy\paste works only inside the editor, but not with other applications.